### PR TITLE
Update to tag 1.6.0

### DIFF
--- a/docker/cnil-pia-back/Dockerfile
+++ b/docker/cnil-pia-back/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     postgresql-client \
  && apt-get clean
 
-RUN git clone --brand 1.6.0 https://github.com/LINCnil/pia-back.git --depth 1 /var/www/
+RUN git clone --branch 1.6.0 https://github.com/LINCnil/pia-back.git --depth 1 /var/www/
 
 COPY database.yml /var/www/config/database.yml
 COPY application.yml /var/www/config/application.yml

--- a/docker/cnil-pia-back/Dockerfile
+++ b/docker/cnil-pia-back/Dockerfile
@@ -7,9 +7,7 @@ RUN apt-get update \
     postgresql-client \
  && apt-get clean
 
-# We should checkout a tag once there is a new release after 1.1
-# RUN git clone https://github.com/LINCnil/pia-back.git /var/www/
-RUN git clone -b master https://github.com/LINCnil/pia-back.git --depth 1 /var/www/
+RUN git clone --brand 1.6.0 https://github.com/LINCnil/pia-back.git --depth 1 /var/www/
 
 COPY database.yml /var/www/config/database.yml
 COPY application.yml /var/www/config/application.yml

--- a/docker/cnil-pia-front/Dockerfile
+++ b/docker/cnil-pia-front/Dockerfile
@@ -23,13 +23,15 @@ RUN mkdir -p /var/www && chown www-data. /var/www/
 
 USER www-data
 
-# We should checkout a tag once there is a new release after 1.5.0
-#RUN git clone https://github.com/LINCnil/pia.git /var/www/pia
-RUN git clone -b master https://github.com/LINCnil/pia.git --depth 1 /var/www/pia
+ENV PIA_VERSION 1.6.0
+RUN git clone --branch $PIA_VERSION https://github.com/LINCnil/pia.git --depth 1 /var/www/pia
 
 WORKDIR /var/www/pia
 
+# Fix for release 1.6.0 : https://github.com/LINCnil/pia/issues/127#issuecomment-369620227
 RUN npm install \
-  && npm run build -prod
+ && cp src/environments/environment.prod.ts.example src/environments/environment.prod.ts \
+ && sed -i -e "s/version: ''/version: '$PIA_VERSION'/g" src/environments/environment.prod.ts \
+ && /var/www/pia/node_modules/@angular/cli/bin/ng build --prod --build-optimizer --sourcemaps
 
 USER root


### PR DESCRIPTION
Hello,

This PR updates the Dockerfiles to use the Git tag in order to have stable versions.

I added a workaround for the front app, because one Typescript file should have the version number registered (see [issue](https://github.com/LINCnil/pia/issues/127#issuecomment-369620227)). 
As the original app hasn't set it up, we do it ourselves in the Dockerfile instead.