### PR TITLE
Install mimemagic

### DIFF
--- a/docker/cnil-pia-back/Dockerfile
+++ b/docker/cnil-pia-back/Dockerfile
@@ -19,6 +19,9 @@ COPY application.yml /var/www/config/application.yml
 WORKDIR /var/www/
 
 RUN gem install bundler
+#install shared-mime info and update mimemagic 
+RUN apt install shared-mime-info
+RUN bundle update mimemagic 
 RUN bundle install
 
 COPY entrypoint /entrypoint


### PR DESCRIPTION
Dear CNIL Team, PIA docker team 
i was eager to use the docker version of Privacy Impact Assessment tool. When i tried to install docker and executed the docker compose file, i got few errors with respect to mimemagic in gem installer. As a consequence i installed shared-mime-info in the backend and mimemagic. After including the following changes to docker/cnil-pia-back/Dockerfile
the line after line number 21


<!--StartFragment-->
    # Install shared-mime info and update mimemagic  
    
    RUN apt install shared-mime-info
    RUN bundle update mimemagic

the docker application worked normally. Can you review it and update it in master branch as well so that it is useful for others.
Best regards